### PR TITLE
Feat: Introduce environment manager for dynamic base URL

### DIFF
--- a/app/src/main/java/eka/care/records/client/utils/Document.kt
+++ b/app/src/main/java/eka/care/records/client/utils/Document.kt
@@ -4,6 +4,7 @@ import com.eka.networking.client.EkaNetwork
 import com.eka.networking.client.NetworkConfig
 import eka.care.records.client.model.EventLog
 import eka.care.records.data.contract.LogInterceptor
+import eka.care.records.data.remote.EnvironmentManager
 
 object Document {
     private var configuration: DocumentConfiguration? = null
@@ -11,6 +12,7 @@ object Document {
 
     fun init(config: DocumentConfiguration) {
         configuration = config
+        EnvironmentManager.setEnvironment(config.environment)
         try {
             EkaNetwork.init(
                 networkConfig = NetworkConfig(

--- a/app/src/main/java/eka/care/records/client/utils/DocumentConfiguration.kt
+++ b/app/src/main/java/eka/care/records/client/utils/DocumentConfiguration.kt
@@ -2,6 +2,7 @@ package eka.care.records.client.utils
 
 import androidx.annotation.Keep
 import com.eka.networking.token.TokenStorage
+import eka.care.records.data.remote.Environment
 
 @Keep
 data class DocumentConfiguration(
@@ -13,5 +14,6 @@ data class DocumentConfiguration(
     val isDebugApp: Boolean = false,
     val apiCallTimeOutInSec: Long = 30L,
     val headers: Map<String, String>,
-    val tokenStorage: TokenStorage
+    val tokenStorage: TokenStorage,
+    val environment: Environment = Environment.PROD,
 )

--- a/app/src/main/java/eka/care/records/data/remote/EnvironmentManager.kt
+++ b/app/src/main/java/eka/care/records/data/remote/EnvironmentManager.kt
@@ -1,0 +1,21 @@
+package eka.care.records.data.remote
+
+object EnvironmentManager {
+    private var currentEnvironment: Environment = Environment.PROD
+
+    fun setEnvironment(env: Environment) {
+        currentEnvironment = env
+    }
+
+    fun getBaseUrl(): String {
+        return when (currentEnvironment) {
+            Environment.STAGING -> "https://api.dev.eka.care"
+            Environment.PROD -> "https://api.eka.care"
+        }
+    }
+}
+
+enum class Environment {
+    STAGING,
+    PROD
+}

--- a/app/src/main/java/eka/care/records/data/remote/api/AwsService.kt
+++ b/app/src/main/java/eka/care/records/data/remote/api/AwsService.kt
@@ -7,11 +7,11 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.PartMap
-import retrofit2.http.Query
 import retrofit2.http.Url
 
 interface AwsService {
@@ -19,7 +19,7 @@ interface AwsService {
     @POST("api/v1/docs")
     suspend fun filesUploadInit(
         @Body request: FilesUploadInitRequest,
-        @Query("p_oid") filterId: String?
+        @Header("X-Pt-Id") filterId: String?
     ): NetworkResponse<FilesUploadInitResponse, FilesUploadInitResponse>
 
     @POST

--- a/app/src/main/java/eka/care/records/data/repository/AwsRepository.kt
+++ b/app/src/main/java/eka/care/records/data/repository/AwsRepository.kt
@@ -4,6 +4,7 @@ import android.webkit.MimeTypeMap
 import com.eka.networking.client.EkaNetwork
 import com.haroldadmin.cnradapter.NetworkResponse
 import eka.care.records.client.utils.Document
+import eka.care.records.data.remote.EnvironmentManager
 import eka.care.records.data.remote.api.AwsService
 import eka.care.records.data.remote.dto.request.Batch
 import eka.care.records.data.remote.dto.request.FileType
@@ -28,7 +29,7 @@ class AwsRepository {
             appId = Document.getConfiguration().appId,
             service = "aws_service"
         ).create(
-            serviceUrl = "https://api.eka.care/mr/",
+            serviceUrl = "${EnvironmentManager.getBaseUrl()}/mr/",
             serviceClass = AwsService::class.java
         )
 

--- a/app/src/main/java/eka/care/records/data/repository/EncountersRepository.kt
+++ b/app/src/main/java/eka/care/records/data/repository/EncountersRepository.kt
@@ -3,6 +3,7 @@ package eka.care.records.data.repository
 import com.eka.networking.client.EkaNetwork
 import com.haroldadmin.cnradapter.NetworkResponse
 import eka.care.records.client.utils.Document
+import eka.care.records.data.remote.EnvironmentManager
 import eka.care.records.data.remote.api.EncountersService
 import eka.care.records.data.remote.dto.request.CaseRequest
 import eka.care.records.data.remote.dto.response.CreateCaseResponse
@@ -16,7 +17,7 @@ class EncountersRepository {
             appId = Document.getConfiguration().appId,
             service = "encounter_service"
         ).create(
-            serviceUrl = "https://api.eka.care/mr/",
+            serviceUrl = "${EnvironmentManager.getBaseUrl()}/mr/",
             serviceClass = EncountersService::class.java
         )
 

--- a/app/src/main/java/eka/care/records/data/repository/MyFileRepository.kt
+++ b/app/src/main/java/eka/care/records/data/repository/MyFileRepository.kt
@@ -2,6 +2,7 @@ package eka.care.records.data.repository
 
 import com.eka.networking.client.EkaNetwork
 import com.haroldadmin.cnradapter.NetworkResponse
+import eka.care.records.data.remote.EnvironmentManager
 import eka.care.records.data.remote.api.MyFileService
 import eka.care.records.data.remote.dto.request.UpdateFileDetailsRequest
 import eka.care.records.data.remote.dto.response.Document
@@ -17,7 +18,7 @@ class MyFileRepository {
                 appId = eka.care.records.client.utils.Document.getConfiguration().appId,
                 service = "files_service"
             ).create(
-                serviceUrl = "https://api.eka.care/mr/",
+                serviceUrl = "${EnvironmentManager.getBaseUrl()}/mr/",
                 serviceClass = MyFileService::class.java
             )
     }

--- a/app/src/main/java/eka/care/records/data/repository/SyncRecordsRepository.kt
+++ b/app/src/main/java/eka/care/records/data/repository/SyncRecordsRepository.kt
@@ -2,6 +2,7 @@ package eka.care.records.data.repository
 
 import com.eka.networking.client.EkaNetwork
 import eka.care.records.client.utils.Document
+import eka.care.records.data.remote.EnvironmentManager
 import eka.care.records.data.remote.api.MyFileService
 import eka.care.records.data.remote.dto.response.GetFilesResponse
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,7 @@ class SyncRecordsRepository() {
             appId = Document.getConfiguration().appId,
             service = "sync_service"
         ).create(
-            serviceUrl = "https://api.eka.care/mr/",
+            serviceUrl = "${EnvironmentManager.getBaseUrl()}/mr/",
             serviceClass = MyFileService::class.java
         )
 


### PR DESCRIPTION
This commit introduces an `EnvironmentManager` to allow dynamic configuration of the API base URL for different environments (Staging, Prod).

- **EnvironmentManager**:
    - Added `EnvironmentManager.kt` with `STAGING` and `PROD` environments.
    - `setEnvironment()`: Sets the current environment.
    - `getBaseUrl()`: Returns the base URL based on the current environment.
- **Configuration**:
    - Added an optional `environment` field (defaulting to `PROD`) to `DocumentConfiguration.kt`.
    - `Document.init()` now calls `EnvironmentManager.setEnvironment()` with the provided environment from the configuration.
- **Repository Updates**:
    - `AwsRepository.kt`, `MyFileRepository.kt`, `SyncRecordsRepository.kt`, and `EncountersRepository.kt` now use `EnvironmentManager.getBaseUrl()` to construct the service URL, replacing the hardcoded production URL.