### PR TITLE
Refactor: Update `scanDocument` parameter from Context to Activity

### DIFF
--- a/app/src/main/java/eka/care/records/client/utils/MediaPickerManager.kt
+++ b/app/src/main/java/eka/care/records/client/utils/MediaPickerManager.kt
@@ -60,7 +60,7 @@ object MediaPickerManager {
         }
     }
 
-    fun scanDocument(context: Context) {
+    fun scanDocument(context: Activity) {
         val options = GmsDocumentScannerOptions.Builder()
             .setGalleryImportAllowed(true)
             .setPageLimit(4)
@@ -70,7 +70,7 @@ object MediaPickerManager {
 
         val scanner = GmsDocumentScanning.getClient(options)
 
-        scanner.getStartScanIntent(context as Activity)
+        scanner.getStartScanIntent(context)
             .addOnSuccessListener { intentSender ->
                 val request = IntentSenderRequest.Builder(intentSender).build()
                 host?.scanDocuments(request)


### PR DESCRIPTION
In `MediaPickerManager.kt`, the `context` parameter for the `scanDocument` function has been changed from `Context` to `Activity`.

This change removes the need for an explicit cast to `Activity` when calling `scanner.getStartScanIntent`.