### PR TITLE
Chore: Bump network dependency and add local maven repository support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
         classpath(libs.org.jacoco.core)
     }
     repositories {
+        mavenLocal()
         flatDir {
             dirs("libs")
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ roomTesting = "2.7.2"
 textRecognition = "16.0.1"
 workRuntimeKtx = "2.8.1"
 playServicesMlkitDocumentScanner = "16.0.0-beta1"
-network = "2.0.4"
+network = "2.0.5"
 coreKtxVersion = "1.7.0"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -19,6 +20,7 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://jitpack.io")
         }
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
- **Dependency Updates**:
    - Updated the `network` library version from `2.0.4` to `2.0.5` in `gradle/libs.versions.toml`.
- **Build Configuration**:
    - Added `mavenLocal()` to the plugin management and dependency resolution repositories in `settings.gradle.kts`.
    - Added `mavenLocal()` to the buildscript repositories in `build.gradle.kts`.