### PR TITLE
Fix: Handle missing source files during record creation

### DIFF
--- a/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
+++ b/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
@@ -639,6 +639,15 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
             isAbhaLink = isAbhaLinked
         )
         val files = files.map { file ->
+            if (!file.exists()) {
+                logRecordSyncEvent(
+                    dId = record.documentId,
+                    bId = record.businessId,
+                    oId = record.ownerId,
+                    msg = "Unable to create record. Source file missing: ${file.path}"
+                )
+                return@supervisorScope null
+            }
             val finalFile = if (file.extension.lowercase() == "pdf") file else Compressor.compress(
                 context,
                 file


### PR DESCRIPTION
- **RecordsRepositoryImpl**:
    - Added a check to verify if each source file exists before processing or compression.
    - Logs a sync event including document, business, and owner IDs if a file is missing.
    - Returns `null` early to prevent errors during record creation when a source file is unavailable.