### PR TITLE
Chore: Bump network dependency to version 2.0.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ roomTesting = "2.7.2"
 textRecognition = "16.0.1"
 workRuntimeKtx = "2.8.1"
 playServicesMlkitDocumentScanner = "16.0.0-beta1"
-network = "2.0.5"
+network = "2.0.6"
 coreKtxVersion = "1.7.0"
 
 [libraries]


### PR DESCRIPTION
- Updated the version of the `network` library from `2.0.5` to `2.0.6` in `gradle/libs.versions.toml`.