### PR TITLE
Refactor: Implement server-synchronized time and handle stale record …

### DIFF
--- a/app/src/main/java/eka/care/records/data/core/FileStorageManagerImpl.kt
+++ b/app/src/main/java/eka/care/records/data/core/FileStorageManagerImpl.kt
@@ -11,6 +11,7 @@ import eka.care.records.client.model.EventLog
 import eka.care.records.client.model.MedicalRecordException
 import eka.care.records.client.utils.Records
 import eka.care.records.data.contract.FileStorageManager
+import eka.care.records.data.utility.TimeProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -44,7 +45,7 @@ class FileStorageManagerImpl(
                 EventLog(
                     params = mutableMapOf<String, Any?>().also {
                         it.put("fileName", file.name)
-                        it.put("time", System.currentTimeMillis())
+                        it.put("time", TimeProvider.nowMillis())
                     },
                     message = "Error saving file: ${e.message}"
                 )
@@ -66,7 +67,7 @@ class FileStorageManagerImpl(
                 EventLog(
                     params = mutableMapOf<String, Any?>().also {
                         it.put("fileName", path)
-                        it.put("time", System.currentTimeMillis())
+                        it.put("time", TimeProvider.nowMillis())
                     },
                     message = "Error deleting file: ${e.message}"
                 )
@@ -99,7 +100,7 @@ class FileStorageManagerImpl(
                     canvas.drawBitmap(bitmap, 0f, 0f, null)
                     page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                     page.close()
-                    val tempFile = File(fileDir, "image${System.currentTimeMillis()}.png")
+                    val tempFile = File(fileDir, "image${TimeProvider.nowMillis()}.png")
                     try {
                         val out = FileOutputStream(tempFile)
                         bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
@@ -110,7 +111,7 @@ class FileStorageManagerImpl(
                             EventLog(
                                 params = mutableMapOf<String, Any?>().also {
                                     it.put("fileName", filePath)
-                                    it.put("time", System.currentTimeMillis())
+                                    it.put("time", TimeProvider.nowMillis())
                                 },
                                 message = "Error saving thumbnail: ${e.message}"
                             )
@@ -127,7 +128,7 @@ class FileStorageManagerImpl(
                     EventLog(
                         params = mutableMapOf<String, Any?>().also {
                             it.put("fileName", filePath)
-                            it.put("time", System.currentTimeMillis())
+                            it.put("time", TimeProvider.nowMillis())
                         },
                         message = "Error generating thumbnail: ${e.message}"
                     )
@@ -143,7 +144,7 @@ class FileStorageManagerImpl(
             Records.logEvent(
                 EventLog(
                     params = mutableMapOf<String, Any?>().also {
-                        it.put("time", System.currentTimeMillis())
+                        it.put("time", TimeProvider.nowMillis())
                     },
                     message = "Error cleaning up files: ${e.message}"
                 )

--- a/app/src/main/java/eka/care/records/data/dao/RecordsDao.kt
+++ b/app/src/main/java/eka/care/records/data/dao/RecordsDao.kt
@@ -122,4 +122,7 @@ interface RecordsDao {
 
     @RawQuery
     suspend fun searchDocument(query: SupportSQLiteQuery): List<RecordEntity>
+
+    @Query("UPDATE eka_records_table SET is_analysing = 0 WHERE is_analysing = 1 AND created_at < :cutoffTimestamp")
+    suspend fun resetStaleAnalysingRecords(cutoffTimestamp: Long)
 }

--- a/app/src/main/java/eka/care/records/data/entity/FileEntity.kt
+++ b/app/src/main/java/eka/care/records/data/entity/FileEntity.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.Fts4
 import androidx.room.PrimaryKey
+import eka.care.records.data.utility.TimeProvider
 
 @Entity(
     tableName = "files_table",
@@ -23,7 +24,7 @@ data class FileEntity(
     @ColumnInfo(name = "document_id") val documentId: String,
     @ColumnInfo(name = "file_path") val filePath: String,
     @ColumnInfo(name = "file_type") var fileType: String,
-    @ColumnInfo(name = "last_used") var lastUsed: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "last_used") var lastUsed: Long = TimeProvider.nowMillis(),
     @ColumnInfo(name = "size_bytes") var sizeBytes: Long = 0L,
     @ColumnInfo(name = "ocr_text") var ocrText: String? = ""
 )

--- a/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
+++ b/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
@@ -785,7 +785,7 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
                 val records = getCaseWithRecords(caseId)?.records ?: emptyList()
                 emit(records)
             } else {
-                val tenMinutesAgo = TimeProvider.nowSeconds() - 60
+                val tenMinutesAgo = TimeProvider.nowSeconds() - 600
                 dao.resetStaleAnalysingRecords(tenMinutesAgo)
                 val dataFlow = dao.readRecords(query).map { records ->
                     records.map {

--- a/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
+++ b/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
@@ -40,6 +40,7 @@ import eka.care.records.data.utility.LoggerConstant.Companion.BUSINESS_ID
 import eka.care.records.data.utility.LoggerConstant.Companion.CASE_ID
 import eka.care.records.data.utility.LoggerConstant.Companion.DOCUMENT_ID
 import eka.care.records.data.utility.LoggerConstant.Companion.OWNER_ID
+import eka.care.records.data.utility.TimeProvider
 import eka.care.records.data.utility.getNetworkCapabilities
 import eka.care.records.data.utility.isNetworkAvailable
 import id.zelory.compressor.Compressor
@@ -61,6 +62,10 @@ import java.io.File
 import java.util.UUID
 
 internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepository {
+    init {
+        TimeProvider.init(context)
+    }
+
     private var dao = RecordsDatabase.getInstance(context).recordsDao()
     private var encountersDao = RecordsDatabase.getInstance(context).encounterDao()
     private val myFileRepository = MyFileRepository()
@@ -615,7 +620,7 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
         if (files.isEmpty()) {
             return@supervisorScope null
         }
-        val time = System.currentTimeMillis() / 1000
+        val time = TimeProvider.nowSeconds()
         val id = UUID.randomUUID().toString()
         val thumbnail =
             if (files.first().extension.lowercase() in listOf("jpg", "jpeg", "png", "webp")) {
@@ -668,7 +673,7 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
                 documentId = record.documentId,
                 filePath = path,
                 fileType = type,
-                lastUsed = System.currentTimeMillis(),
+                lastUsed = TimeProvider.nowMillis(),
                 sizeBytes = FileUtils.getFileSize(filePath = path)
             )
         }
@@ -780,6 +785,8 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
                 val records = getCaseWithRecords(caseId)?.records ?: emptyList()
                 emit(records)
             } else {
+                val tenMinutesAgo = TimeProvider.nowSeconds() - 60
+                dao.resetStaleAnalysingRecords(tenMinutesAgo)
                 val dataFlow = dao.readRecords(query).map { records ->
                     records.map {
                         RecordModel(
@@ -965,7 +972,7 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
                     documentId = record.documentId,
                     filePath = filePath,
                     fileType = fileType,
-                    lastUsed = System.currentTimeMillis(),
+                    lastUsed = TimeProvider.nowMillis(),
                     sizeBytes = FileUtils.getFileSize(filePath)
                 )
             )
@@ -999,7 +1006,7 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
     private fun updateRecordFileLastUsed(files: List<FileEntity>) {
         CoroutineScope(Dispatchers.IO).launch {
             val updatedFiles =
-                files.map { file -> file.copy(lastUsed = System.currentTimeMillis()) }
+                files.map { file -> file.copy(lastUsed = TimeProvider.nowMillis()) }
             dao.updateRecordFiles(updatedFiles)
         }
     }
@@ -1126,8 +1133,8 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
                 ownerId = ownerId,
                 status = status,
                 uiState = uiStatus,
-                createdAt = createdAt ?: (System.currentTimeMillis() / 1000),
-                updatedAt = updatedAt ?: (System.currentTimeMillis() / 1000),
+                createdAt = createdAt ?: TimeProvider.nowSeconds(),
+                updatedAt = updatedAt ?: TimeProvider.nowSeconds(),
             )
         )
         return@supervisorScope id

--- a/app/src/main/java/eka/care/records/data/utility/TimeProvider.kt
+++ b/app/src/main/java/eka/care/records/data/utility/TimeProvider.kt
@@ -1,0 +1,31 @@
+package eka.care.records.data.utility
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.util.concurrent.atomic.AtomicLong
+
+object TimeProvider {
+
+    private const val PREF_NAME = "eka_time_provider"
+    private const val KEY_OFFSET = "server_time_offset"
+
+    private val offset = AtomicLong(0L)
+    private var prefs: SharedPreferences? = null
+
+    fun init(context: Context) {
+        prefs = context.applicationContext.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        offset.set(prefs?.getLong(KEY_OFFSET, 0L) ?: 0L)
+    }
+
+    // Call this with the server's Unix epoch millis whenever you get a server response.
+    // Persists the offset so it survives app restarts.
+    fun updateFromServerTime(serverTimeMillis: Long) {
+        val newOffset = serverTimeMillis - System.currentTimeMillis()
+        offset.set(newOffset)
+        prefs?.edit()?.putLong(KEY_OFFSET, newOffset)?.apply()
+    }
+
+    fun nowMillis(): Long = System.currentTimeMillis() + offset.get()
+
+    fun nowSeconds(): Long = nowMillis() / 1000
+}

--- a/app/src/main/java/eka/care/records/sync/RecordsSync.kt
+++ b/app/src/main/java/eka/care/records/sync/RecordsSync.kt
@@ -22,6 +22,9 @@ import eka.care.records.data.repository.SyncRecordsRepository
 import eka.care.records.data.utility.LoggerConstant.Companion.BUSINESS_ID
 import eka.care.records.data.utility.LoggerConstant.Companion.DOCUMENT_ID
 import eka.care.records.data.utility.LoggerConstant.Companion.OWNER_ID
+import eka.care.records.data.utility.TimeProvider
+import java.text.SimpleDateFormat
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -102,6 +105,12 @@ class RecordsSync(
             )
             if (response?.body() == null) {
                 break
+            }
+            response.headers()["Date"]?.let { dateHeader ->
+                try {
+                    val sdf = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+                    sdf.parse(dateHeader)?.time?.let { TimeProvider.updateFromServerTime(it) }
+                } catch (_: Exception) { }
             }
             response.body()?.let {
                 storeRecords(records = it.items, businessId = businessId)


### PR DESCRIPTION
…states

- **Time Synchronization**:
    - Introduced `TimeProvider` utility to manage and persist a server time offset via `SharedPreferences`, ensuring consistent timestamps across the app.
    - Updated `RecordsSync` to parse the `Date` header from server responses to update the `TimeProvider` offset.
    - Replaced `System.currentTimeMillis()` with `TimeProvider.nowMillis()` and `TimeProvider.nowSeconds()` in `FileEntity`, `FileStorageManagerImpl`, and `RecordsRepositoryImpl`.

- **Database & Repository**:
    - Added `resetStaleAnalysingRecords` to `RecordsDao` to reset the `is_analysing` flag for records that have been in an analysis state longer than a specific cutoff.
    - Updated `RecordsRepositoryImpl` to initialize `TimeProvider` and trigger the stale record reset logic when reading records.
    - Improved record and file creation logic to use synchronized timestamps for `createdAt`, `updatedAt`, and `lastUsed` fields.