### PR TITLE
fix: Downsample image thumbnails to avoid oversized bitmap rendering

### DIFF
--- a/app/src/main/java/eka/care/records/data/core/FileStorageManagerImpl.kt
+++ b/app/src/main/java/eka/care/records/data/core/FileStorageManagerImpl.kt
@@ -2,6 +2,7 @@ package eka.care.records.data.core
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
@@ -20,6 +21,13 @@ import java.util.UUID
 class FileStorageManagerImpl(
     private val context: Context
 ) : FileStorageManager {
+
+    companion object {
+        // Decoded thumbnails must stay far below RecordingCanvas.MAX_BITMAP_SIZE
+        // (100MB); keeping the smaller edge near this value caps the decode at
+        // a few MB regardless of source resolution.
+        private const val THUMBNAIL_MIN_DIMENSION_PX = 1080
+    }
 
     private val fileDir by lazy {
         File(context.cacheDir, "medical_records").apply {
@@ -118,9 +126,29 @@ class FileStorageManagerImpl(
                     }
                     tempFile.path
                 } else {
-                    val thumbnailPath = "${file.parent}/thumbnail_${file.name}"
-                    file.copyTo(File(thumbnailPath), overwrite = true)
-                    return@withContext thumbnailPath
+                    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeFile(file.path, bounds)
+                    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) {
+                        val thumbnailPath = "${file.parent}/thumbnail_${file.name}"
+                        file.copyTo(File(thumbnailPath), overwrite = true)
+                        return@withContext thumbnailPath
+                    }
+                    var sampleSize = 1
+                    while (bounds.outWidth / (sampleSize * 2) >= THUMBNAIL_MIN_DIMENSION_PX &&
+                        bounds.outHeight / (sampleSize * 2) >= THUMBNAIL_MIN_DIMENSION_PX
+                    ) {
+                        sampleSize *= 2
+                    }
+                    val bitmap = BitmapFactory.decodeFile(
+                        file.path,
+                        BitmapFactory.Options().apply { inSampleSize = sampleSize }
+                    ) ?: return@withContext null
+                    val thumbFile = File(fileDir, "thumb_${UUID.randomUUID()}.jpg")
+                    FileOutputStream(thumbFile).use { out ->
+                        bitmap.compress(Bitmap.CompressFormat.JPEG, 85, out)
+                    }
+                    bitmap.recycle()
+                    return@withContext thumbFile.path
                 }
             } catch (e: Exception) {
                 Records.logEvent(

--- a/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
+++ b/app/src/main/java/eka/care/records/data/repository/RecordsRepositoryImpl.kt
@@ -617,14 +617,9 @@ internal class RecordsRepositoryImpl(private val context: Context) : RecordsRepo
         }
         val time = System.currentTimeMillis() / 1000
         val id = UUID.randomUUID().toString()
-        val thumbnail =
-            if (files.first().extension.lowercase() in listOf("jpg", "jpeg", "png", "webp")) {
-                files.first().path
-            } else {
-                fileStorageManager.generateThumbnail(
-                    filePath = files.first().path
-                )
-            }
+        val thumbnail = fileStorageManager.generateThumbnail(
+            filePath = files.first().path
+        ) ?: files.first().path
         val record = RecordEntity(
             documentId = id,
             businessId = businessId,


### PR DESCRIPTION
Large source images were copied as-is for thumbnails, producing bitmaps that could exceed RecordingCanvas.MAX_BITMAP_SIZE when rendered.

- Decode image bounds first and pick an inSampleSize that keeps the smaller edge near 1080px, then re-encode as JPEG (quality 85)
- Fall back to a plain file copy when bounds can't be decoded
- Route all record thumbnails through generateThumbnail() instead of using raw image paths directly, falling back to the original file